### PR TITLE
Fix duplicate configmap entries for forward to and listen from

### DIFF
--- a/helm/signalfx-smart-gateway/templates/configmap.yaml
+++ b/helm/signalfx-smart-gateway/templates/configmap.yaml
@@ -46,6 +46,11 @@ data:
         {{- if $index}},{{- end }}
         {{toJson $forwarder}}
         {{- end }}
+        {{- if $.Values.forwarders }},{{- end }}
+        {{- range $index, $forwarder := $.Values.forwarders }}
+        {{- if $index}},{{- end }}
+        {{toJson $forwarder}}
+        {{- end }}
         {{- else }}
         {{- range $index, $forwarder := $.Values.forwarders }}
         {{- if $index}},{{- end }}

--- a/helm/signalfx-smart-gateway/templates/configmap.yaml
+++ b/helm/signalfx-smart-gateway/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
       {{ else }}
       "ClusterName": {{ toJson $.Values.clusterName}},
       {{- end }}
-      {{- range $k, $v := .conf}}{{ if not (eq $k "Listeners" "Forwarders" "TargetClusterAddresses" "ClusterName" "ClusterOperation")}}
+      {{- range $k, $v := .conf}}{{ if not (eq $k "ListenFrom" "ForwardTo" "TargetClusterAddresses" "ClusterName" "ClusterOperation")}}
       "{{ $k }}": {{ toJson $v }},
       {{- end }}{{ end }}
       {{- if (or (and (eq $key "gateway") (gt (int .count) 1)) (and (eq $key "distributor") (gt (int .count) 0))) }}


### PR DESCRIPTION
Noticed that additional forwarders defined in the top level chart values were not "merged" into the config as documented.  This pr ensures that they are merged.  I also noticed that ForwardTo and ListenFrom were duplicated.